### PR TITLE
feat: Add lowering tests for float compound assignment 

### DIFF
--- a/toolchain/lower/testdata/builtins/float.carbon
+++ b/toolchain/lower/testdata/builtins/float.carbon
@@ -10,6 +10,10 @@
 // TIP: To dump output, run:
 // TIP:   bazel run //toolchain/testing:file_test -- --dump_output --file_tests=toolchain/lower/testdata/builtins/float.carbon
 
+// --- basic.carbon
+
+library "[[@TEST_NAME]]";
+
 fn Negate(a: f64) -> f64 = "float.negate";
 fn TestNegate(a: f64) -> f64 { return Negate(a); }
 
@@ -43,8 +47,24 @@ fn TestGreater(a: f64, b: f64) -> bool { return Greater(a, b); }
 fn GreaterEq(a: f64, b: f64) -> bool = "float.greater_eq";
 fn TestGreaterEq(a: f64, b: f64) -> bool { return GreaterEq(a, b); }
 
-// CHECK:STDOUT: ; ModuleID = 'float.carbon'
-// CHECK:STDOUT: source_filename = "float.carbon"
+// --- compound_assign.carbon
+
+library "[[@TEST_NAME]]";
+
+fn Add(a: f64*, b: f64) = "float.add_assign";
+fn TestAdd(a: f64*, b: f64) { Add(a, b); }
+
+fn Sub(a: f64*, b: f64) = "float.sub_assign";
+fn TestSub(a: f64*, b: f64) { Sub(a, b); }
+
+fn Mul(a: f64*, b: f64) = "float.mul_assign";
+fn TestMul(a: f64*, b: f64) { Mul(a, b); }
+
+fn Div(a: f64*, b: f64) = "float.div_assign";
+fn TestDiv(a: f64*, b: f64) { Div(a, b); }
+
+// CHECK:STDOUT: ; ModuleID = 'basic.carbon'
+// CHECK:STDOUT: source_filename = "basic.carbon"
 // CHECK:STDOUT:
 // CHECK:STDOUT: define double @_CTestNegate.Main(double %a) !dbg !4 {
 // CHECK:STDOUT: entry:
@@ -118,39 +138,95 @@ fn TestGreaterEq(a: f64, b: f64) -> bool { return GreaterEq(a, b); }
 // CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
 // CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
 // CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
-// CHECK:STDOUT: !3 = !DIFile(filename: "float.carbon", directory: "")
-// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestNegate", linkageName: "_CTestNegate.Main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !3 = !DIFile(filename: "basic.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestNegate", linkageName: "_CTestNegate.Main", scope: null, file: !3, line: 16, type: !5, spFlags: DISPFlagDefinition, unit: !2)
 // CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
 // CHECK:STDOUT: !6 = !{}
-// CHECK:STDOUT: !7 = !DILocation(line: 14, column: 39, scope: !4)
-// CHECK:STDOUT: !8 = !DILocation(line: 14, column: 32, scope: !4)
-// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "TestAdd", linkageName: "_CTestAdd.Main", scope: null, file: !3, line: 17, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !10 = !DILocation(line: 17, column: 44, scope: !9)
-// CHECK:STDOUT: !11 = !DILocation(line: 17, column: 37, scope: !9)
-// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "TestSub", linkageName: "_CTestSub.Main", scope: null, file: !3, line: 20, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !13 = !DILocation(line: 20, column: 44, scope: !12)
-// CHECK:STDOUT: !14 = !DILocation(line: 20, column: 37, scope: !12)
-// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "TestMul", linkageName: "_CTestMul.Main", scope: null, file: !3, line: 23, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !16 = !DILocation(line: 23, column: 44, scope: !15)
-// CHECK:STDOUT: !17 = !DILocation(line: 23, column: 37, scope: !15)
-// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "TestDiv", linkageName: "_CTestDiv.Main", scope: null, file: !3, line: 26, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !19 = !DILocation(line: 26, column: 44, scope: !18)
-// CHECK:STDOUT: !20 = !DILocation(line: 26, column: 37, scope: !18)
-// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "TestEq", linkageName: "_CTestEq.Main", scope: null, file: !3, line: 29, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !22 = !DILocation(line: 29, column: 44, scope: !21)
-// CHECK:STDOUT: !23 = !DILocation(line: 29, column: 37, scope: !21)
-// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "TestNeq", linkageName: "_CTestNeq.Main", scope: null, file: !3, line: 32, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !25 = !DILocation(line: 32, column: 45, scope: !24)
-// CHECK:STDOUT: !26 = !DILocation(line: 32, column: 38, scope: !24)
-// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "TestLess", linkageName: "_CTestLess.Main", scope: null, file: !3, line: 35, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !28 = !DILocation(line: 35, column: 46, scope: !27)
-// CHECK:STDOUT: !29 = !DILocation(line: 35, column: 39, scope: !27)
-// CHECK:STDOUT: !30 = distinct !DISubprogram(name: "TestLessEq", linkageName: "_CTestLessEq.Main", scope: null, file: !3, line: 38, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !31 = !DILocation(line: 38, column: 48, scope: !30)
-// CHECK:STDOUT: !32 = !DILocation(line: 38, column: 41, scope: !30)
-// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "TestGreater", linkageName: "_CTestGreater.Main", scope: null, file: !3, line: 41, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !34 = !DILocation(line: 41, column: 49, scope: !33)
-// CHECK:STDOUT: !35 = !DILocation(line: 41, column: 42, scope: !33)
-// CHECK:STDOUT: !36 = distinct !DISubprogram(name: "TestGreaterEq", linkageName: "_CTestGreaterEq.Main", scope: null, file: !3, line: 44, type: !5, spFlags: DISPFlagDefinition, unit: !2)
-// CHECK:STDOUT: !37 = !DILocation(line: 44, column: 51, scope: !36)
-// CHECK:STDOUT: !38 = !DILocation(line: 44, column: 44, scope: !36)
+// CHECK:STDOUT: !7 = !DILocation(line: 16, column: 39, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 16, column: 32, scope: !4)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "TestAdd", linkageName: "_CTestAdd.Main", scope: null, file: !3, line: 19, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = !DILocation(line: 19, column: 44, scope: !9)
+// CHECK:STDOUT: !11 = !DILocation(line: 19, column: 37, scope: !9)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "TestSub", linkageName: "_CTestSub.Main", scope: null, file: !3, line: 22, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = !DILocation(line: 22, column: 44, scope: !12)
+// CHECK:STDOUT: !14 = !DILocation(line: 22, column: 37, scope: !12)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "TestMul", linkageName: "_CTestMul.Main", scope: null, file: !3, line: 25, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = !DILocation(line: 25, column: 44, scope: !15)
+// CHECK:STDOUT: !17 = !DILocation(line: 25, column: 37, scope: !15)
+// CHECK:STDOUT: !18 = distinct !DISubprogram(name: "TestDiv", linkageName: "_CTestDiv.Main", scope: null, file: !3, line: 28, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !19 = !DILocation(line: 28, column: 44, scope: !18)
+// CHECK:STDOUT: !20 = !DILocation(line: 28, column: 37, scope: !18)
+// CHECK:STDOUT: !21 = distinct !DISubprogram(name: "TestEq", linkageName: "_CTestEq.Main", scope: null, file: !3, line: 31, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !22 = !DILocation(line: 31, column: 44, scope: !21)
+// CHECK:STDOUT: !23 = !DILocation(line: 31, column: 37, scope: !21)
+// CHECK:STDOUT: !24 = distinct !DISubprogram(name: "TestNeq", linkageName: "_CTestNeq.Main", scope: null, file: !3, line: 34, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !25 = !DILocation(line: 34, column: 45, scope: !24)
+// CHECK:STDOUT: !26 = !DILocation(line: 34, column: 38, scope: !24)
+// CHECK:STDOUT: !27 = distinct !DISubprogram(name: "TestLess", linkageName: "_CTestLess.Main", scope: null, file: !3, line: 37, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !28 = !DILocation(line: 37, column: 46, scope: !27)
+// CHECK:STDOUT: !29 = !DILocation(line: 37, column: 39, scope: !27)
+// CHECK:STDOUT: !30 = distinct !DISubprogram(name: "TestLessEq", linkageName: "_CTestLessEq.Main", scope: null, file: !3, line: 40, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !31 = !DILocation(line: 40, column: 48, scope: !30)
+// CHECK:STDOUT: !32 = !DILocation(line: 40, column: 41, scope: !30)
+// CHECK:STDOUT: !33 = distinct !DISubprogram(name: "TestGreater", linkageName: "_CTestGreater.Main", scope: null, file: !3, line: 43, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !34 = !DILocation(line: 43, column: 49, scope: !33)
+// CHECK:STDOUT: !35 = !DILocation(line: 43, column: 42, scope: !33)
+// CHECK:STDOUT: !36 = distinct !DISubprogram(name: "TestGreaterEq", linkageName: "_CTestGreaterEq.Main", scope: null, file: !3, line: 46, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !37 = !DILocation(line: 46, column: 51, scope: !36)
+// CHECK:STDOUT: !38 = !DILocation(line: 46, column: 44, scope: !36)
+// CHECK:STDOUT: ; ModuleID = 'compound_assign.carbon'
+// CHECK:STDOUT: source_filename = "compound_assign.carbon"
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CTestAdd.Main(ptr %a, double %b) !dbg !4 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Add.call = load double, ptr %a, align 8, !dbg !7
+// CHECK:STDOUT:   %Add.call1 = fadd double %Add.call, %b, !dbg !7
+// CHECK:STDOUT:   store double %Add.call1, ptr %a, align 8, !dbg !7
+// CHECK:STDOUT:   ret void, !dbg !8
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CTestSub.Main(ptr %a, double %b) !dbg !9 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Sub.call = load double, ptr %a, align 8, !dbg !10
+// CHECK:STDOUT:   %Sub.call1 = fsub double %Sub.call, %b, !dbg !10
+// CHECK:STDOUT:   store double %Sub.call1, ptr %a, align 8, !dbg !10
+// CHECK:STDOUT:   ret void, !dbg !11
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CTestMul.Main(ptr %a, double %b) !dbg !12 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Mul.call = load double, ptr %a, align 8, !dbg !13
+// CHECK:STDOUT:   %Mul.call1 = fmul double %Mul.call, %b, !dbg !13
+// CHECK:STDOUT:   store double %Mul.call1, ptr %a, align 8, !dbg !13
+// CHECK:STDOUT:   ret void, !dbg !14
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: define void @_CTestDiv.Main(ptr %a, double %b) !dbg !15 {
+// CHECK:STDOUT: entry:
+// CHECK:STDOUT:   %Div.call = load double, ptr %a, align 8, !dbg !16
+// CHECK:STDOUT:   %Div.call1 = fdiv double %Div.call, %b, !dbg !16
+// CHECK:STDOUT:   store double %Div.call1, ptr %a, align 8, !dbg !16
+// CHECK:STDOUT:   ret void, !dbg !17
+// CHECK:STDOUT: }
+// CHECK:STDOUT:
+// CHECK:STDOUT: !llvm.module.flags = !{!0, !1}
+// CHECK:STDOUT: !llvm.dbg.cu = !{!2}
+// CHECK:STDOUT:
+// CHECK:STDOUT: !0 = !{i32 7, !"Dwarf Version", i32 5}
+// CHECK:STDOUT: !1 = !{i32 2, !"Debug Info Version", i32 3}
+// CHECK:STDOUT: !2 = distinct !DICompileUnit(language: DW_LANG_C, file: !3, producer: "carbon", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug)
+// CHECK:STDOUT: !3 = !DIFile(filename: "compound_assign.carbon", directory: "")
+// CHECK:STDOUT: !4 = distinct !DISubprogram(name: "TestAdd", linkageName: "_CTestAdd.Main", scope: null, file: !3, line: 5, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !5 = !DISubroutineType(types: !6)
+// CHECK:STDOUT: !6 = !{}
+// CHECK:STDOUT: !7 = !DILocation(line: 5, column: 32, scope: !4)
+// CHECK:STDOUT: !8 = !DILocation(line: 5, column: 1, scope: !4)
+// CHECK:STDOUT: !9 = distinct !DISubprogram(name: "TestSub", linkageName: "_CTestSub.Main", scope: null, file: !3, line: 8, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !10 = !DILocation(line: 8, column: 32, scope: !9)
+// CHECK:STDOUT: !11 = !DILocation(line: 8, column: 1, scope: !9)
+// CHECK:STDOUT: !12 = distinct !DISubprogram(name: "TestMul", linkageName: "_CTestMul.Main", scope: null, file: !3, line: 11, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !13 = !DILocation(line: 11, column: 32, scope: !12)
+// CHECK:STDOUT: !14 = !DILocation(line: 11, column: 1, scope: !12)
+// CHECK:STDOUT: !15 = distinct !DISubprogram(name: "TestDiv", linkageName: "_CTestDiv.Main", scope: null, file: !3, line: 14, type: !5, spFlags: DISPFlagDefinition, unit: !2)
+// CHECK:STDOUT: !16 = !DILocation(line: 14, column: 32, scope: !15)
+// CHECK:STDOUT: !17 = !DILocation(line: 14, column: 1, scope: !15)


### PR DESCRIPTION
Adds lowering tests for the floating-point compound assignment
operators (`+=`, `-=`, `*=`, `/=`).

The new tests are added to `toolchain/lower/testdata/builtins/float.carbon`,
following the structure of the existing integer tests in
`toolchain/lower/testdata/builtins/int.carbon`.